### PR TITLE
fix: start server after services added

### DIFF
--- a/cpp/olink_tests/many_objects/server.cpp
+++ b/cpp/olink_tests/many_objects/server.cpp
@@ -25,10 +25,10 @@ int main(int argc, char* argv[])
 
     auto portNumber = 8000;
     ApiGear::PocoImpl::OLinkHost testHost(registry, [](auto /*level*/, auto /*msg*/) {});
-    testHost.listen(portNumber);
     auto begin = std::chrono::high_resolution_clock::now();
 
     auto services = prepareServices(registry);
+    testHost.listen(portNumber);
     auto testStarted = false;
 
     auto servicesfinished = 0;

--- a/cpp/olink_tests/single_object_many_threads/server.cpp
+++ b/cpp/olink_tests/single_object_many_threads/server.cpp
@@ -62,11 +62,11 @@ int main(int argc, char* argv[])
 
     auto portNumber = 8000;
     ApiGear::PocoImpl::OLinkHost testHost(registry, [](auto /*level*/, auto /*msg*/){ });
-    testHost.listen(portNumber);
 
     auto source = std::make_shared<Cpp::Api::TestApi0>();
     auto sourceService = std::make_shared<TestService>(source, registry);
     registry.addSource(sourceService);
+    testHost.listen(portNumber);
         
     bool testStarted = false;
     // Will be overwritten with receiving link message


### PR DESCRIPTION
Changes order of steps of preparing an  olink server for cpp . If client wants to make a connection before the server is up, the olink client will reconnect until it will succeed. On server start, connection gets established, but if a services is not already to service, the Olink will fail to link service side with a client side. To avoid such sitiation the services should be added to registry befor server starts listening.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here --> https://github.com/apigear-io/template-cpp14/issues/145

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->